### PR TITLE
Fix envrc-like export escaping

### DIFF
--- a/outputs/env_oneline.go
+++ b/outputs/env_oneline.go
@@ -18,7 +18,10 @@ func (o *OutputOneline) Save(name string, namespace string, writer io.Writer, va
 			continue
 		}
 
-		value := escapeRegex.ReplaceAllString(variable.Value.(string), "\\$1")
+		value := fmt.Sprintf("%s", variable.Value)
+		if strings.Contains(value, "(") {
+			value = fmt.Sprintf("\"%s\"", value)
+		}
 
 		_, err := fmt.Fprintf(writer, "%s=\"%s\" ", strings.ToUpper(variable.Name), value)
 

--- a/outputs/envrc.go
+++ b/outputs/envrc.go
@@ -5,8 +5,6 @@ import (
 
 	"strings"
 
-	"regexp"
-
 	"io"
 
 	"github.com/Wikia/konfigurator/model"
@@ -14,17 +12,18 @@ import (
 
 type OutputEnvrc struct{}
 
-var escapeRegex = regexp.MustCompile(`([$\\_\x96])`)
-
 func (o *OutputEnvrc) Save(name string, namespace string, writer io.Writer, vars []model.Variable) error {
 	for _, variable := range vars {
 		if variable.Type == model.REFERENCED {
 			continue
 		}
 
-		value := escapeRegex.ReplaceAllString(variable.Value.(string), "\\$1")
+		value := fmt.Sprintf("%s", variable.Value)
+		if strings.Contains(value, "(") {
+			value = fmt.Sprintf("\"%s\"", value)
+		}
 
-		_, err := fmt.Fprintf(writer, "export %s=\"%s\"\n", strings.ToUpper(variable.Name), value)
+		_, err := fmt.Fprintf(writer, "export %s=%s\n", strings.ToUpper(variable.Name), value)
 
 		if err != nil {
 			return err


### PR DESCRIPTION
It seems previous escaping was bit excessive. It should be better now.